### PR TITLE
Add TXT File Sending with Repeat and Line Endings

### DIFF
--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -47,12 +47,11 @@
             this.sending_Status = new System.Windows.Forms.Label();
             this.Title = new System.Windows.Forms.Label();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-            this.textbox_filepath = new System.Windows.Forms.TextBox();
             this.button_browsefile = new System.Windows.Forms.Button();
-            this.numeric_updown_interval = new System.Windows.Forms.NumericUpDown();
-            this.label2 = new System.Windows.Forms.Label();
+            this.textbox_filepath = new System.Windows.Forms.Label();
+            this.textBox_interval = new System.Windows.Forms.TextBox();
+            this.button_start_repeat = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numeric_updown_interval)).BeginInit();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -254,54 +253,41 @@
             // 
             this.openFileDialog1.FileName = "openFileDialog1";
             // 
-            // textbox_filepath
-            // 
-            this.textbox_filepath.Location = new System.Drawing.Point(284, 313);
-            this.textbox_filepath.Name = "textbox_filepath";
-            this.textbox_filepath.ReadOnly = true;
-            this.textbox_filepath.Size = new System.Drawing.Size(380, 22);
-            this.textbox_filepath.TabIndex = 7;
-            // 
             // button_browsefile
             // 
-            this.button_browsefile.Location = new System.Drawing.Point(887, 313);
+            this.button_browsefile.Location = new System.Drawing.Point(845, 305);
             this.button_browsefile.Name = "button_browsefile";
-            this.button_browsefile.Size = new System.Drawing.Size(75, 23);
+            this.button_browsefile.Size = new System.Drawing.Size(117, 36);
             this.button_browsefile.TabIndex = 8;
             this.button_browsefile.Text = "Browse";
             this.button_browsefile.UseVisualStyleBackColor = true;
             this.button_browsefile.Click += new System.EventHandler(this.button_browsefile_Click);
             // 
-            // numeric_updown_interval
+            // textbox_filepath
             // 
-            this.numeric_updown_interval.Location = new System.Drawing.Point(792, 312);
-            this.numeric_updown_interval.Maximum = new decimal(new int[] {
-            60,
-            0,
-            0,
-            0});
-            this.numeric_updown_interval.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numeric_updown_interval.Name = "numeric_updown_interval";
-            this.numeric_updown_interval.Size = new System.Drawing.Size(46, 22);
-            this.numeric_updown_interval.TabIndex = 9;
-            this.numeric_updown_interval.Value = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
+            this.textbox_filepath.Font = new System.Drawing.Font("Nirmala UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textbox_filepath.Location = new System.Drawing.Point(277, 316);
+            this.textbox_filepath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.textbox_filepath.Name = "textbox_filepath";
+            this.textbox_filepath.Size = new System.Drawing.Size(333, 25);
+            this.textbox_filepath.TabIndex = 11;
             // 
-            // label2
+            // textBox_interval
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(670, 316);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(116, 16);
-            this.label2.TabIndex = 10;
-            this.label2.Text = "Interval (seconds):";
+            this.textBox_interval.Location = new System.Drawing.Point(659, 287);
+            this.textBox_interval.Name = "textBox_interval";
+            this.textBox_interval.Size = new System.Drawing.Size(100, 22);
+            this.textBox_interval.TabIndex = 12;
+            // 
+            // button_start_repeat
+            // 
+            this.button_start_repeat.Location = new System.Drawing.Point(714, 309);
+            this.button_start_repeat.Name = "button_start_repeat";
+            this.button_start_repeat.Size = new System.Drawing.Size(117, 36);
+            this.button_start_repeat.TabIndex = 13;
+            this.button_start_repeat.Text = "Start Repeating";
+            this.button_start_repeat.UseVisualStyleBackColor = true;
+            this.button_start_repeat.Click += new System.EventHandler(this.button_start_repeat_Click_1);
             // 
             // SerialCom
             // 
@@ -309,10 +295,10 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.ClientSize = new System.Drawing.Size(967, 346);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.numeric_updown_interval);
-            this.Controls.Add(this.button_browsefile);
+            this.Controls.Add(this.button_start_repeat);
+            this.Controls.Add(this.textBox_interval);
             this.Controls.Add(this.textbox_filepath);
+            this.Controls.Add(this.button_browsefile);
             this.Controls.Add(this.Title);
             this.Controls.Add(this.sending_Status);
             this.Controls.Add(this.button1);
@@ -329,7 +315,6 @@
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SerialCom_FormClosed);
             this.Load += new System.EventHandler(this.SerialCom_Load);
             this.groupBox1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.numeric_updown_interval)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -355,10 +340,10 @@
         private System.Windows.Forms.Label sending_Status;
         private System.Windows.Forms.Label Title;
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
-        private System.Windows.Forms.TextBox textbox_filepath;
         private System.Windows.Forms.Button button_browsefile;
-        private System.Windows.Forms.NumericUpDown numeric_updown_interval;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label textbox_filepath;
+        private System.Windows.Forms.TextBox textBox_interval;
+        private System.Windows.Forms.Button button_start_repeat;
     }
 }
 

--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -52,6 +52,7 @@
             this.textBox_interval = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
             this.button_start_repeat = new System.Windows.Forms.Button();
+            this.comboBox_lineEnding = new System.Windows.Forms.ComboBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.textBox_interval)).BeginInit();
             this.SuspendLayout();
@@ -301,6 +302,15 @@
             this.button_start_repeat.TabIndex = 16;
             this.button_start_repeat.Text = "Start Repeating";
             this.button_start_repeat.UseVisualStyleBackColor = true;
+            this.button_start_repeat.Click += new System.EventHandler(this.button_start_repeat_Click);
+            // 
+            // comboBox_lineEnding
+            // 
+            this.comboBox_lineEnding.FormattingEnabled = true;
+            this.comboBox_lineEnding.Location = new System.Drawing.Point(556, 298);
+            this.comboBox_lineEnding.Name = "comboBox_lineEnding";
+            this.comboBox_lineEnding.Size = new System.Drawing.Size(121, 24);
+            this.comboBox_lineEnding.TabIndex = 17;
             // 
             // SerialCom
             // 
@@ -308,6 +318,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.ClientSize = new System.Drawing.Size(967, 334);
+            this.Controls.Add(this.comboBox_lineEnding);
             this.Controls.Add(this.button_start_repeat);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.textBox_interval);
@@ -360,6 +371,7 @@
         private System.Windows.Forms.NumericUpDown textBox_interval;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button button_start_repeat;
+        private System.Windows.Forms.ComboBox comboBox_lineEnding;
     }
 }
 

--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -49,9 +49,9 @@
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.button_browsefile = new System.Windows.Forms.Button();
             this.textbox_filepath = new System.Windows.Forms.Label();
-            this.button_start_repeat = new System.Windows.Forms.Button();
             this.textBox_interval = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
+            this.button_start_repeat = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.textBox_interval)).BeginInit();
             this.SuspendLayout();
@@ -274,16 +274,6 @@
             this.textbox_filepath.Size = new System.Drawing.Size(333, 25);
             this.textbox_filepath.TabIndex = 11;
             // 
-            // button_start_repeat
-            // 
-            this.button_start_repeat.Location = new System.Drawing.Point(845, 293);
-            this.button_start_repeat.Name = "button_start_repeat";
-            this.button_start_repeat.Size = new System.Drawing.Size(117, 36);
-            this.button_start_repeat.TabIndex = 13;
-            this.button_start_repeat.Text = "Start Repeating";
-            this.button_start_repeat.UseVisualStyleBackColor = true;
-            this.button_start_repeat.Click += new System.EventHandler(this.button_start_repeat_Click_1);
-            // 
             // textBox_interval
             // 
             this.textBox_interval.Location = new System.Drawing.Point(782, 301);
@@ -294,14 +284,23 @@
             // label2
             // 
             this.label2.Font = new System.Drawing.Font("Nirmala UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(685, 301);
+            this.label2.Location = new System.Drawing.Point(695, 301);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(90, 25);
+            this.label2.Size = new System.Drawing.Size(80, 25);
             this.label2.TabIndex = 15;
-            this.label2.Text = "intervals";
+            this.label2.Text = "intervals:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             this.label2.Click += new System.EventHandler(this.label2_Click_1);
+            // 
+            // button_start_repeat
+            // 
+            this.button_start_repeat.Location = new System.Drawing.Point(845, 299);
+            this.button_start_repeat.Name = "button_start_repeat";
+            this.button_start_repeat.Size = new System.Drawing.Size(110, 27);
+            this.button_start_repeat.TabIndex = 16;
+            this.button_start_repeat.Text = "Start Repeating";
+            this.button_start_repeat.UseVisualStyleBackColor = true;
             // 
             // SerialCom
             // 
@@ -309,9 +308,9 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.ClientSize = new System.Drawing.Size(967, 334);
+            this.Controls.Add(this.button_start_repeat);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.textBox_interval);
-            this.Controls.Add(this.button_start_repeat);
             this.Controls.Add(this.textbox_filepath);
             this.Controls.Add(this.button_browsefile);
             this.Controls.Add(this.Title);
@@ -358,9 +357,9 @@
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.Button button_browsefile;
         private System.Windows.Forms.Label textbox_filepath;
-        private System.Windows.Forms.Button button_start_repeat;
         private System.Windows.Forms.NumericUpDown textBox_interval;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button button_start_repeat;
     }
 }
 

--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -49,9 +49,11 @@
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.button_browsefile = new System.Windows.Forms.Button();
             this.textbox_filepath = new System.Windows.Forms.Label();
-            this.textBox_interval = new System.Windows.Forms.TextBox();
             this.button_start_repeat = new System.Windows.Forms.Button();
+            this.textBox_interval = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.textBox_interval)).BeginInit();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -72,7 +74,7 @@
             this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.groupBox1.Size = new System.Drawing.Size(273, 346);
+            this.groupBox1.Size = new System.Drawing.Size(273, 334);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "         Serial Com Settings";
@@ -205,10 +207,10 @@
             // button_SEND
             // 
             this.button_SEND.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_SEND.Location = new System.Drawing.Point(845, 254);
+            this.button_SEND.Location = new System.Drawing.Point(845, 257);
             this.button_SEND.Margin = new System.Windows.Forms.Padding(4);
             this.button_SEND.Name = "button_SEND";
-            this.button_SEND.Size = new System.Drawing.Size(117, 44);
+            this.button_SEND.Size = new System.Drawing.Size(117, 29);
             this.button_SEND.TabIndex = 3;
             this.button_SEND.Text = "Send";
             this.button_SEND.UseVisualStyleBackColor = true;
@@ -255,9 +257,9 @@
             // 
             // button_browsefile
             // 
-            this.button_browsefile.Location = new System.Drawing.Point(845, 305);
+            this.button_browsefile.Location = new System.Drawing.Point(845, 213);
             this.button_browsefile.Name = "button_browsefile";
-            this.button_browsefile.Size = new System.Drawing.Size(117, 36);
+            this.button_browsefile.Size = new System.Drawing.Size(117, 34);
             this.button_browsefile.TabIndex = 8;
             this.button_browsefile.Text = "Browse";
             this.button_browsefile.UseVisualStyleBackColor = true;
@@ -266,22 +268,15 @@
             // textbox_filepath
             // 
             this.textbox_filepath.Font = new System.Drawing.Font("Nirmala UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textbox_filepath.Location = new System.Drawing.Point(277, 316);
+            this.textbox_filepath.Location = new System.Drawing.Point(277, 310);
             this.textbox_filepath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.textbox_filepath.Name = "textbox_filepath";
             this.textbox_filepath.Size = new System.Drawing.Size(333, 25);
             this.textbox_filepath.TabIndex = 11;
             // 
-            // textBox_interval
-            // 
-            this.textBox_interval.Location = new System.Drawing.Point(659, 287);
-            this.textBox_interval.Name = "textBox_interval";
-            this.textBox_interval.Size = new System.Drawing.Size(100, 22);
-            this.textBox_interval.TabIndex = 12;
-            // 
             // button_start_repeat
             // 
-            this.button_start_repeat.Location = new System.Drawing.Point(714, 309);
+            this.button_start_repeat.Location = new System.Drawing.Point(845, 293);
             this.button_start_repeat.Name = "button_start_repeat";
             this.button_start_repeat.Size = new System.Drawing.Size(117, 36);
             this.button_start_repeat.TabIndex = 13;
@@ -289,14 +284,34 @@
             this.button_start_repeat.UseVisualStyleBackColor = true;
             this.button_start_repeat.Click += new System.EventHandler(this.button_start_repeat_Click_1);
             // 
+            // textBox_interval
+            // 
+            this.textBox_interval.Location = new System.Drawing.Point(782, 301);
+            this.textBox_interval.Name = "textBox_interval";
+            this.textBox_interval.Size = new System.Drawing.Size(57, 22);
+            this.textBox_interval.TabIndex = 14;
+            // 
+            // label2
+            // 
+            this.label2.Font = new System.Drawing.Font("Nirmala UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(685, 301);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(90, 25);
+            this.label2.TabIndex = 15;
+            this.label2.Text = "intervals";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.label2.Click += new System.EventHandler(this.label2_Click_1);
+            // 
             // SerialCom
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.ClientSize = new System.Drawing.Size(967, 346);
-            this.Controls.Add(this.button_start_repeat);
+            this.ClientSize = new System.Drawing.Size(967, 334);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.textBox_interval);
+            this.Controls.Add(this.button_start_repeat);
             this.Controls.Add(this.textbox_filepath);
             this.Controls.Add(this.button_browsefile);
             this.Controls.Add(this.Title);
@@ -315,6 +330,7 @@
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SerialCom_FormClosed);
             this.Load += new System.EventHandler(this.SerialCom_Load);
             this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.textBox_interval)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -342,8 +358,9 @@
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.Button button_browsefile;
         private System.Windows.Forms.Label textbox_filepath;
-        private System.Windows.Forms.TextBox textBox_interval;
         private System.Windows.Forms.Button button_start_repeat;
+        private System.Windows.Forms.NumericUpDown textBox_interval;
+        private System.Windows.Forms.Label label2;
     }
 }
 

--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -46,7 +46,13 @@
             this.button1 = new System.Windows.Forms.Button();
             this.sending_Status = new System.Windows.Forms.Label();
             this.Title = new System.Windows.Forms.Label();
+            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+            this.textbox_filepath = new System.Windows.Forms.TextBox();
+            this.button_browsefile = new System.Windows.Forms.Button();
+            this.numeric_updown_interval = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_updown_interval)).BeginInit();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -67,7 +73,7 @@
             this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.groupBox1.Size = new System.Drawing.Size(273, 314);
+            this.groupBox1.Size = new System.Drawing.Size(273, 346);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "         Serial Com Settings";
@@ -244,12 +250,69 @@
             this.Title.Text = "Serial GUI Connector";
             this.Title.Click += new System.EventHandler(this.Title_Click);
             // 
+            // openFileDialog1
+            // 
+            this.openFileDialog1.FileName = "openFileDialog1";
+            // 
+            // textbox_filepath
+            // 
+            this.textbox_filepath.Location = new System.Drawing.Point(284, 313);
+            this.textbox_filepath.Name = "textbox_filepath";
+            this.textbox_filepath.ReadOnly = true;
+            this.textbox_filepath.Size = new System.Drawing.Size(380, 22);
+            this.textbox_filepath.TabIndex = 7;
+            // 
+            // button_browsefile
+            // 
+            this.button_browsefile.Location = new System.Drawing.Point(887, 313);
+            this.button_browsefile.Name = "button_browsefile";
+            this.button_browsefile.Size = new System.Drawing.Size(75, 23);
+            this.button_browsefile.TabIndex = 8;
+            this.button_browsefile.Text = "Browse";
+            this.button_browsefile.UseVisualStyleBackColor = true;
+            this.button_browsefile.Click += new System.EventHandler(this.button_browsefile_Click);
+            // 
+            // numeric_updown_interval
+            // 
+            this.numeric_updown_interval.Location = new System.Drawing.Point(792, 312);
+            this.numeric_updown_interval.Maximum = new decimal(new int[] {
+            60,
+            0,
+            0,
+            0});
+            this.numeric_updown_interval.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numeric_updown_interval.Name = "numeric_updown_interval";
+            this.numeric_updown_interval.Size = new System.Drawing.Size(46, 22);
+            this.numeric_updown_interval.TabIndex = 9;
+            this.numeric_updown_interval.Value = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(670, 316);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(116, 16);
+            this.label2.TabIndex = 10;
+            this.label2.Text = "Interval (seconds):";
+            // 
             // SerialCom
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.ClientSize = new System.Drawing.Size(967, 314);
+            this.ClientSize = new System.Drawing.Size(967, 346);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.numeric_updown_interval);
+            this.Controls.Add(this.button_browsefile);
+            this.Controls.Add(this.textbox_filepath);
             this.Controls.Add(this.Title);
             this.Controls.Add(this.sending_Status);
             this.Controls.Add(this.button1);
@@ -266,6 +329,7 @@
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SerialCom_FormClosed);
             this.Load += new System.EventHandler(this.SerialCom_Load);
             this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.numeric_updown_interval)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -290,6 +354,11 @@
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Label sending_Status;
         private System.Windows.Forms.Label Title;
+        private System.Windows.Forms.OpenFileDialog openFileDialog1;
+        private System.Windows.Forms.TextBox textbox_filepath;
+        private System.Windows.Forms.Button button_browsefile;
+        private System.Windows.Forms.NumericUpDown numeric_updown_interval;
+        private System.Windows.Forms.Label label2;
     }
 }
 

--- a/RxTx with Arduino/SerialCom.Designer.cs
+++ b/RxTx with Arduino/SerialCom.Designer.cs
@@ -262,7 +262,7 @@
             this.button_browsefile.Name = "button_browsefile";
             this.button_browsefile.Size = new System.Drawing.Size(117, 34);
             this.button_browsefile.TabIndex = 8;
-            this.button_browsefile.Text = "Browse";
+            this.button_browsefile.Text = "Add File";
             this.button_browsefile.UseVisualStyleBackColor = true;
             this.button_browsefile.Click += new System.EventHandler(this.button_browsefile_Click);
             // 

--- a/RxTx with Arduino/SerialCom.cs
+++ b/RxTx with Arduino/SerialCom.cs
@@ -139,15 +139,17 @@ namespace RxTx_with_Arduino
 
                 if (!string.IsNullOrEmpty(textToSend))
                 {
-                    serialPort1.Write(textToSend);
                     serialPort1.Write(textToSend + GetLineEnding());
                     richTextBox_Txt_Receiver.Text += "";
                     textBox_Txt_Send.Text = "";
-                    sending_Status.Text = "Message is sending...";
+                    sending_Status.Text = "Message Sent"; // Immediate update
                     sending_Status.ForeColor = Color.Black;
-                    button_SEND.Enabled = false;
+                    button_SEND.Enabled = true; // Re-enable immediately
+                    waitForEnd = false; // Reset for repeat
+                    textbox_filepath.Text = ""; // clear the file path
+                    fileContent = ""; // Clear fileContent after send
 
-                    //textbox_filepath.Text = ""; // Clears path but keeps fileContent
+
                 }
                 else
                 {
@@ -175,29 +177,21 @@ namespace RxTx_with_Arduino
             if (sending_Status.Text == "Ready")
             {
                 receivingStatusAsync();
-                // Send \n to acknowledge receipt when data is fully received
-                if (serialPort1.IsOpen)
-                {
-                    serialPort1.Write("\n");
-                }
+                // No acknowledgment: //serialPort1.Write("\n");
             }
-
             richTextBox_Txt_Receiver.Text += serialDataIn;
         }
 
         private async void sendingStatus()
         {
-            if (serialDataIn.Contains('\n'))
-            {
-                button_SEND.Enabled = true;
-                button_browsefile.Enabled = true;
-                sending_Status.Text = "Message Sent";
-                sending_Status.ForeColor = Color.Black;
-                await Task.Delay(2000);
-                sending_Status.Text = "Ready";
-                sending_Status.ForeColor = Color.Black;
-                waitForEnd = false;
-            }
+            button_SEND.Enabled = true;
+            button_browsefile.Enabled = true;
+            sending_Status.Text = "Message Sent";
+            sending_Status.ForeColor = Color.Black;
+            await Task.Delay(2000);
+            sending_Status.Text = "Ready";
+            sending_Status.ForeColor = Color.Black;
+            waitForEnd = false;
         }
 
         private async Task receivingStatusAsync()
@@ -242,8 +236,8 @@ namespace RxTx_with_Arduino
 
             if (openFileDialog.ShowDialog() == DialogResult.OK)
             {
-                textbox_filepath.Text = openFileDialog.FileName; // Show file path in label
-                fileContent = File.ReadAllText(openFileDialog.FileName); // Read file content
+                textbox_filepath.Text = openFileDialog.FileName;
+                fileContent = File.ReadAllText(openFileDialog.FileName);
             }
         }
 

--- a/RxTx with Arduino/SerialCom.cs
+++ b/RxTx with Arduino/SerialCom.cs
@@ -33,9 +33,11 @@ namespace RxTx_with_Arduino
             buttonOPEN.Enabled = true;
             button_CLOSE.Enabled = false;
             button_SEND.Enabled = false;
+            button_start_repeat.Enabled = false;
             button_browsefile.Enabled = false;
             progressBar_STATUSbar.Value = 0;
             labelSTATUS.Text = "Disconnected";
+            button_start_repeat.Text = "Start Repeating";
             labelSTATUS.ForeColor = Color.Red;
 
             comboBox_BAUD_RATE.Text = "9600";
@@ -55,8 +57,10 @@ namespace RxTx_with_Arduino
                 button_CLOSE.Enabled = true;
                 button_SEND.Enabled = true;
                 button_browsefile.Enabled = true;
+                button_start_repeat.Enabled = true;
                 progressBar_STATUSbar.Value = 100;
                 labelSTATUS.Text = "CONNECTED";
+                button_start_repeat.Text = "Start Repeating";
                 labelSTATUS.ForeColor = Color.Green;
 
                 comboBox_BAUD_RATE.Text = "9600";
@@ -79,6 +83,7 @@ namespace RxTx_with_Arduino
                     button_CLOSE.Enabled = false;
                     button_SEND.Enabled = false;
                     button_browsefile.Enabled = false;
+                    button_start_repeat.Enabled = false;
                     progressBar_STATUSbar.Value = 0;
                     labelSTATUS.Text = "Disconnected";
                     richTextBox_Txt_Receiver.Text = "";
@@ -238,43 +243,7 @@ namespace RxTx_with_Arduino
             }
         }
 
-        private void button_start_repeat_Click(object sender, EventArgs e)
-        {
-            if (!serialPort1.IsOpen)
-            {
-                MessageBox.Show("Please open the serial port first!");
-                return;
-            }
-
-            if (string.IsNullOrEmpty(fileContent))
-            {
-                MessageBox.Show("Please load a text file first!");
-                return;
-            }
-
-            if (!int.TryParse(textBox_interval.Text, out int intervalSeconds) || intervalSeconds <= 0)
-            {
-                MessageBox.Show("Please enter a valid interval in seconds!");
-                return;
-            }
-
-            if (!isRepeating)
-            {
-                repeatTimer.Interval = intervalSeconds * 1000;
-                repeatTimer.Start();
-                isRepeating = true;
-                button_start_repeat.Text = "Stop Repeating";
-                sending_Status.Text = "Repeating every " + intervalSeconds + " seconds";
-            }
-            else
-            {
-                repeatTimer.Stop();
-                isRepeating = false;
-                button_start_repeat.Text = "Start Repeating";
-                sending_Status.Text = "Ready";
-                sending_Status.ForeColor = Color.Gray;
-            }
-        }
+       
 
         private void RepeatTimerElapsed(object sender, ElapsedEventArgs e)
         {
@@ -342,6 +311,9 @@ namespace RxTx_with_Arduino
             }
         }
 
-        
+        private void label2_Click_1(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/RxTx with Arduino/SerialCom.cs
+++ b/RxTx with Arduino/SerialCom.cs
@@ -40,6 +40,9 @@ namespace RxTx_with_Arduino
             button_start_repeat.Text = "Start Repeating";
             labelSTATUS.ForeColor = Color.Red;
 
+            comboBox_lineEnding.Items.AddRange(new string[] { "None", "Line Feed (LF)", "Carriage Return (CR)", "CR + LF (CRLF)" });
+            comboBox_lineEnding.SelectedIndex = 0;
+
             comboBox_BAUD_RATE.Text = "9600";
             string[] portLists = SerialPort.GetPortNames();
             comboBox_COM_PORT.Items.AddRange(portLists);
@@ -137,6 +140,7 @@ namespace RxTx_with_Arduino
                 if (!string.IsNullOrEmpty(textToSend))
                 {
                     serialPort1.Write(textToSend);
+                    serialPort1.Write(textToSend + GetLineEnding());
                     richTextBox_Txt_Receiver.Text += "";
                     textBox_Txt_Send.Text = "";
                     sending_Status.Text = "Message is sending...";
@@ -243,7 +247,7 @@ namespace RxTx_with_Arduino
             }
         }
 
-       
+
 
         private void RepeatTimerElapsed(object sender, ElapsedEventArgs e)
         {
@@ -251,12 +255,24 @@ namespace RxTx_with_Arduino
             {
                 if (serialPort1.IsOpen && !waitForEnd)
                 {
-                    serialPort1.Write(fileContent);
+                    serialPort1.Write(fileContent + GetLineEnding());
                     richTextBox_Txt_Receiver.Text += "";
                     sending_Status.Text = "Message sent (repeating)";
                     sending_Status.ForeColor = Color.Black;
                 }
             }));
+        }
+
+        private string GetLineEnding()
+        {
+            switch (comboBox_lineEnding.SelectedIndex)
+            {
+                case 1: return "\n"; // Line Feed (LF)
+                case 2: return "\r"; // Carriage Return (CR)
+                case 3: return "\r\n"; // CR + LF (CRLF)
+                case 0: // None
+                default: return "";
+            }
         }
 
         private void label1_Click(object sender, EventArgs e) { }
@@ -274,6 +290,16 @@ namespace RxTx_with_Arduino
         }
 
         private void button_start_repeat_Click_1(object sender, EventArgs e)
+        {
+            
+        }
+
+        private void label2_Click_1(object sender, EventArgs e)
+        {
+
+        }
+
+        private void button_start_repeat_Click(object sender, EventArgs e)
         {
             if (!serialPort1.IsOpen)
             {
@@ -309,11 +335,6 @@ namespace RxTx_with_Arduino
                 sending_Status.Text = "Ready";
                 sending_Status.ForeColor = Color.Gray;
             }
-        }
-
-        private void label2_Click_1(object sender, EventArgs e)
-        {
-
         }
     }
 }

--- a/RxTx with Arduino/SerialCom.cs
+++ b/RxTx with Arduino/SerialCom.cs
@@ -295,5 +295,15 @@ namespace RxTx_with_Arduino
         {
 
         }
+
+        private void button_browsefile_HelpRequest(object sender, EventArgs e)
+        {
+
+        }
+
+        private void button_browsefile_Click(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/RxTx with Arduino/SerialCom.cs
+++ b/RxTx with Arduino/SerialCom.cs
@@ -8,51 +8,32 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.IO.Ports;
-using System.Drawing.Text;
+using System.IO;
+using System.Timers;
 
 namespace RxTx_with_Arduino
 {
     public partial class SerialCom : Form
     {
-        string serialDataIn;  //To get serial data 
+        string serialDataIn;  // To get serial data 
         bool waitForEnd = false;
-        
+        private System.Timers.Timer repeatTimer; 
+        private string fileContent; // To store the TXT file content
+        private bool isRepeating = false; 
+
         public SerialCom()
         {
             InitializeComponent();
-        }
-
-        private void label1_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label2_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void groupBox1_Enter(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label3_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label4_Click(object sender, EventArgs e)
-        {
-
+            repeatTimer = new System.Timers.Timer();
+            repeatTimer.Elapsed += RepeatTimerElapsed; 
         }
 
         private void SerialCom_Load(object sender, EventArgs e)
         {
-
             buttonOPEN.Enabled = true;
             button_CLOSE.Enabled = false;
             button_SEND.Enabled = false;
+            button_browsefile.Enabled = false;
             progressBar_STATUSbar.Value = 0;
             labelSTATUS.Text = "Disconnected";
             labelSTATUS.ForeColor = Color.Red;
@@ -60,9 +41,6 @@ namespace RxTx_with_Arduino
             comboBox_BAUD_RATE.Text = "9600";
             string[] portLists = SerialPort.GetPortNames();
             comboBox_COM_PORT.Items.AddRange(portLists);
-
-
-
         }
 
         private void buttonOPEN_Click(object sender, EventArgs e)
@@ -76,20 +54,17 @@ namespace RxTx_with_Arduino
                 buttonOPEN.Enabled = false;
                 button_CLOSE.Enabled = true;
                 button_SEND.Enabled = true;
+                button_browsefile.Enabled = true;
                 progressBar_STATUSbar.Value = 100;
                 labelSTATUS.Text = "CONNECTED";
                 labelSTATUS.ForeColor = Color.Green;
 
-                comboBox_BAUD_RATE.Text= "9600";
-
-
-                
+                comboBox_BAUD_RATE.Text = "9600";
             }
             catch (Exception error)
             {
                 MessageBox.Show(error.Message);
             }
-
         }
 
         private void button_CLOSE_Click(object sender, EventArgs e)
@@ -103,6 +78,7 @@ namespace RxTx_with_Arduino
                     buttonOPEN.Enabled = true;
                     button_CLOSE.Enabled = false;
                     button_SEND.Enabled = false;
+                    button_browsefile.Enabled = false;
                     progressBar_STATUSbar.Value = 0;
                     labelSTATUS.Text = "Disconnected";
                     richTextBox_Txt_Receiver.Text = "";
@@ -113,16 +89,11 @@ namespace RxTx_with_Arduino
                     sending_Status.Text = "Ready";
                     sending_Status.ForeColor = Color.Gray;
                 }
-                catch(Exception error)
+                catch (Exception error)
                 {
                     MessageBox.Show(error.Message);
                 }
             }
-        }
-
-        private void SerialCom_FormClosed(object sender, FormClosedEventArgs e)
-        {
-
         }
 
         private void SerialCom_FormClosing(object sender, FormClosingEventArgs e)
@@ -131,9 +102,10 @@ namespace RxTx_with_Arduino
             {
                 try
                 {
+                    repeatTimer.Stop(); // Stop timer if running
                     serialPort1.Close();
                 }
-                catch(Exception error)
+                catch (Exception error)
                 {
                     MessageBox.Show(error.Message);
                 }
@@ -144,43 +116,36 @@ namespace RxTx_with_Arduino
         {
             try
             {
-                
-                
-
-                if (waitForEnd == true)
+                if (waitForEnd)
                 {
                     button_SEND.Enabled = false;
+                    MessageBox.Show("Please Wait!" + serialDataIn + "\n" + waitForEnd);
+                    return;
+                }
 
-                    MessageBox.Show("Please Wait!"+serialDataIn+"\n"+waitForEnd);
+                string textToSend = textBox_Txt_Send.Text;
+                if (!string.IsNullOrEmpty(fileContent) && string.IsNullOrEmpty(textToSend))
+                {
+                    textToSend = fileContent;
+                }
+
+                if (!string.IsNullOrEmpty(textToSend))
+                {
+                    serialPort1.Write(textToSend);
+                    richTextBox_Txt_Receiver.Text += "";
+                    textBox_Txt_Send.Text = "";
+                    sending_Status.Text = "Message is sending...";
+                    sending_Status.ForeColor = Color.Black;
+                    button_SEND.Enabled = false;
+
+                    //textbox_filepath.Text = ""; // Clears path but keeps fileContent
                 }
                 else
                 {
-                    if (textBox_Txt_Send.Text != "")
-                    {
-                        serialPort1.Write(textBox_Txt_Send.Text);
-                        //richTextBox_Txt_Receiver.Text += "Me: ";
-                        richTextBox_Txt_Receiver.Text += "";
-
-
-                        textBox_Txt_Send.Text = "";
-                        sending_Status.Text = "Message is sending...";
-                        sending_Status.ForeColor = Color.Black;
-                        button_SEND.Enabled = false;
-                    }
-                    else
-                    {
-                        MessageBox.Show("Invalid input");
-                    }
-
-                    
+                    MessageBox.Show("Invalid input or no file loaded");
                 }
-
-                
-                
-                
-
             }
-            catch(Exception error)
+            catch (Exception error)
             {
                 MessageBox.Show(error.Message);
             }
@@ -189,21 +154,11 @@ namespace RxTx_with_Arduino
         private void serialPort1_DataReceived(object sender, SerialDataReceivedEventArgs e)
         {
             serialDataIn = serialPort1.ReadExisting();
-
-
-            
             this.Invoke(new EventHandler(ShowData));
-            
-
-
         }
 
         private void ShowData(object sender, EventArgs e)
-
         {
-
-           
-
             if (sending_Status.Text == "Message is sending...")
             {
                 sendingStatus();
@@ -211,64 +166,42 @@ namespace RxTx_with_Arduino
             if (sending_Status.Text == "Ready")
             {
                 receivingStatusAsync();
-               
-
+                // Send \n to acknowledge receipt when data is fully received
+                if (serialPort1.IsOpen)
+                {
+                    serialPort1.Write("\n");
+                }
             }
-
-
-
-
-            
 
             richTextBox_Txt_Receiver.Text += serialDataIn;
         }
+
         private async void sendingStatus()
         {
-
             if (serialDataIn.Contains('\n'))
             {
-                
                 button_SEND.Enabled = true;
+                button_browsefile.Enabled = true;
                 sending_Status.Text = "Message Sent";
-                //richTextBox_Txt_Receiver.Text += "\n";
                 sending_Status.ForeColor = Color.Black;
                 await Task.Delay(2000);
                 sending_Status.Text = "Ready";
                 sending_Status.ForeColor = Color.Black;
-
                 waitForEnd = false;
-
-
-               
-
             }
-
-
         }
 
         private async Task receivingStatusAsync()
         {
-            if (serialDataIn == "\n")
-            {
-                
-                button_SEND.Enabled = true;
-                sending_Status.Text = "Message Received";
-                
-                sending_Status.ForeColor = Color.Black;
-               await Task.Delay(2000);
-                sending_Status.Text = "Ready";
-                sending_Status.ForeColor = Color.Black;
-
-                waitForEnd = false;
-
-
-
-
-
-            }
-
-
-
+            // Removed the condition serialDataIn == "\n" since we’re now sending \n after any received data
+            button_SEND.Enabled = true;
+            button_browsefile.Enabled = true;
+            sending_Status.Text = "Message Received";
+            sending_Status.ForeColor = Color.Black;
+            await Task.Delay(2000);
+            sending_Status.Text = "Ready";
+            sending_Status.ForeColor = Color.Black;
+            waitForEnd = false;
         }
 
         private void richTextBox_Txt_Receiver_TextChanged(object sender, EventArgs e)
@@ -286,24 +219,129 @@ namespace RxTx_with_Arduino
         {
             if (e.KeyCode == Keys.Enter)
             {
-                //enter key is down
                 button_SEND_Click(sender, e);
             }
         }
 
-        private void Title_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void button_browsefile_HelpRequest(object sender, EventArgs e)
-        {
-
-        }
-
         private void button_browsefile_Click(object sender, EventArgs e)
         {
+            OpenFileDialog openFileDialog = new OpenFileDialog
+            {
+                Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
+                Title = "Select a Text File"
+            };
+
+            if (openFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                textbox_filepath.Text = openFileDialog.FileName; // Show file path in label
+                fileContent = File.ReadAllText(openFileDialog.FileName); // Read file content
+            }
+        }
+
+        private void button_start_repeat_Click(object sender, EventArgs e)
+        {
+            if (!serialPort1.IsOpen)
+            {
+                MessageBox.Show("Please open the serial port first!");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(fileContent))
+            {
+                MessageBox.Show("Please load a text file first!");
+                return;
+            }
+
+            if (!int.TryParse(textBox_interval.Text, out int intervalSeconds) || intervalSeconds <= 0)
+            {
+                MessageBox.Show("Please enter a valid interval in seconds!");
+                return;
+            }
+
+            if (!isRepeating)
+            {
+                repeatTimer.Interval = intervalSeconds * 1000;
+                repeatTimer.Start();
+                isRepeating = true;
+                button_start_repeat.Text = "Stop Repeating";
+                sending_Status.Text = "Repeating every " + intervalSeconds + " seconds";
+            }
+            else
+            {
+                repeatTimer.Stop();
+                isRepeating = false;
+                button_start_repeat.Text = "Start Repeating";
+                sending_Status.Text = "Ready";
+                sending_Status.ForeColor = Color.Gray;
+            }
+        }
+
+        private void RepeatTimerElapsed(object sender, ElapsedEventArgs e)
+        {
+            this.Invoke(new Action(() =>
+            {
+                if (serialPort1.IsOpen && !waitForEnd)
+                {
+                    serialPort1.Write(fileContent);
+                    richTextBox_Txt_Receiver.Text += "";
+                    sending_Status.Text = "Message sent (repeating)";
+                    sending_Status.ForeColor = Color.Black;
+                }
+            }));
+        }
+
+        private void label1_Click(object sender, EventArgs e) { }
+        private void label2_Click(object sender, EventArgs e) { }
+        private void groupBox1_Enter(object sender, EventArgs e) { }
+        private void label3_Click(object sender, EventArgs e) { }
+        private void label4_Click(object sender, EventArgs e) { }
+        private void SerialCom_FormClosed(object sender, FormClosedEventArgs e) { }
+        private void Title_Click(object sender, EventArgs e) { }
+        private void button_browsefile_HelpRequest(object sender, EventArgs e) { }
+
+        private void textbox_filepath_TextChanged(object sender, EventArgs e)
+        {
 
         }
+
+        private void button_start_repeat_Click_1(object sender, EventArgs e)
+        {
+            if (!serialPort1.IsOpen)
+            {
+                MessageBox.Show("Please open the serial port first!");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(fileContent))
+            {
+                MessageBox.Show("Please load a text file first!");
+                return;
+            }
+
+            if (!int.TryParse(textBox_interval.Text, out int intervalSeconds) || intervalSeconds <= 0)
+            {
+                MessageBox.Show("Please enter a valid interval in seconds!");
+                return;
+            }
+
+            if (!isRepeating)
+            {
+                repeatTimer.Interval = intervalSeconds * 1000;
+                repeatTimer.Start();
+                isRepeating = true;
+                button_start_repeat.Text = "Stop Repeating";
+                sending_Status.Text = "Repeating every " + intervalSeconds + " seconds";
+            }
+            else
+            {
+                repeatTimer.Stop();
+                isRepeating = false;
+                button_start_repeat.Text = "Start Repeating";
+                sending_Status.Text = "Ready";
+                sending_Status.ForeColor = Color.Gray;
+            }
+        }
+
+        
     }
 }

--- a/RxTx with Arduino/SerialCom.resx
+++ b/RxTx with Arduino/SerialCom.resx
@@ -120,4 +120,7 @@
   <metadata name="serialPort1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>146, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
This PR implements the features requested in #5:
- Sending text from a `.txt` file with repeat at user-specified intervals.
- Optional line endings (None, LF, CR, CRLF) via a dropdown.


@Juris3D, I’ve implemented your requests in PR #2  Please test it out and let me know if it works for you.
